### PR TITLE
AN-123700: Fix Raft lease bug

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -662,6 +662,7 @@ func (r *raft) becomePreCandidate() {
 	// r.Term or change r.Vote.
 	r.step = stepCandidate
 	r.votes = make(map[uint64]bool)
+	r.lead = None
 	r.tick = r.tickElection
 	r.state = StatePreCandidate
 	r.logger.Infof("%x became pre-candidate at term %d", r.id, r.Term)


### PR DESCRIPTION
-When a node becomes a pre-candidate, it sets its cached value for
the leader to none


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
